### PR TITLE
Support for multiple responses and partial object match

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { createServer } = require('grpc-kit');
 const { Metadata } = require('grpc');
+const partial_compare = require('partial-compare');
 const UNEXPECTED_INPUT_PATTERN_ERROR = {
   code: 3,
   message: "unexpected input pattern"
@@ -291,6 +292,9 @@ function isMatched(actual, expected) {
   if (typeof expected === 'string') {
     return JSON.stringify(actual).match(new RegExp(expected));
   } else {
+    if (process.env.GRPC_MOCK_COMPARE && process.env.GRPC_MOCK_COMPARE == "sparse") {
+      return partial_compare(actual, expected);
+    }
     return JSON.stringify(actual) === JSON.stringify(expected);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,6 +1270,11 @@
         "lcid": "^1.0.0"
       }
     },
+    "partial-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/partial-compare/-/partial-compare-1.0.1.tgz",
+      "integrity": "sha1-aKwbhk5GO3E+ZZMdIIPBVgYIgzo="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.3.0",
     "grpc": "^1.17.0",
-    "grpc-kit": "^0.2.0"
+    "grpc-kit": "^0.2.0",
+    "partial-compare": "^1.0.1"
   },
   "devDependencies": {
     "intelli-espower-loader": "^1.0.1",


### PR DESCRIPTION
This patch adds support for different responses based on the input matches. I tried to enable this capability with as small a change as possible (i.e., I didn't want to restructure to much). This has a couple of consequences:

the configuration format is a little clunky as you specify the method name for each rule even though it is the same method with just different input/output.
the patch essentially works by ensuring even though there are multiple handlers generated only a single response is given. to coordinate this some state is maintained. This may not be the cleanest but it seemed to be the most direct approach without significant restructuring.