### PR TITLE
Adding custom matchers

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,7 +291,10 @@ class HandlerFactory {
 function isMatched(actual, expected) {
   if (typeof expected === 'string') {
     return JSON.stringify(actual).match(new RegExp(expected));
-  } else {
+  } else if (typeof expected === 'function' && expected.length == 1) {
+	return expected(actual);
+  } else
+  {
     if (process.env.GRPC_MOCK_COMPARE && process.env.GRPC_MOCK_COMPARE == "sparse") {
       return partial_compare(actual, expected);
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,7 @@ const mockServer = createMockServer({
   packageName,
   serviceName,
   rules: [
+    { method: "hello", input: (input) => { return input == '{ "message": "foobar" }'; }, output: { message: "barfoo" } },
     { method: "hello", input: { message: "test" }, output: { message: "Hello" } },
     { method: "hello", input: { message: "Hi" }, output: { message: "Back at you" } },
     { method: "goodbye", input: ".*", output: { message: "Goodbye" } },
@@ -75,6 +76,14 @@ describe("grpc-mock", () => {
   });
 
   afterEach(() => mockServer.clearInteractions());
+
+  it("responds barfoo", () => {
+    return hello({ message : "foobar" })
+      .then((res) => {
+        assert(res.message === "barfoo");
+      })
+      .catch(assert);
+  });
 
   it("responds Hello", () => {
     return hello({ message : "test" })


### PR DESCRIPTION
I would like to allow custom functions as matchers for inputs beside the regex and partial_compare matchers.